### PR TITLE
Improved user feedback for labs_SpawnFromTemplate

### DIFF
--- a/Import/CustomTechDocs/Import/Method/labs_SpawnFromTemplate.xml
+++ b/Import/CustomTechDocs/Import/Method/labs_SpawnFromTemplate.xml
@@ -13,6 +13,12 @@
 * 09-01-2017 : Packaged for deployment to MyI
 */
 
+// check if current selected item is a template
+if (this.getProperty("is_template","0") == "0")
+{
+    return aras.AlertError("Action can only be performed on a template document.");
+}
+
 var inn = this.getInnovator();
 var thisId = this.getID();
 var thisDoc = inn.getItemById("tp_Block",thisId);


### PR DESCRIPTION
## Description
In the previous version the Action "Create New From Template" will throw the following error message when action is performed on an item that is no template: "The method "labs_SpawnFromTemplate" failed." This default message is not very helpful for the end user. This change adds a more user friendly text for the case users want to create new documents from a non-template document.


## Reason
<!-- Type an x into the square brackets to check the box. -->
- [ ] Bug fix
- [x] Feature enhancement
- [ ] New feature
- [ ] Documentation update
- [ ] Upgrade
- [ ] Other

**Are you responding to a filed Issue? (bug report, feature request, documentation request, etc)**
<!-- If you are submitting a fix for an Issue, reference the issue by number to link it. For example, you can link Issue 5 by entering #5. -->


## Testing
### Aras Innovator 
* Major version: <!-- 12.0 | 11.0 | 10.0 -->
* Service pack(s): <!-- SP0 | SP1 | SP2 | etc... -->

### Browsers
- [ ] Internet Explorer 11
- [ ] Firefox ESR 
- [x] Chrome 
- [ ] Edge 

**Does this pull request include known issues?**
<!-- Add details here -->


## Checklist
- [x] Did you confirm the Install Steps in the README are still correct?
- [ ] If this PR adds or changes functionality, did you update the Usage Steps in the README?
- [ ] Did you add your GitHub user name to the "Credits" section in the README?